### PR TITLE
Fix await_containerrun docstring

### DIFF
--- a/src/kivecli/await_containerrrun.py
+++ b/src/kivecli/await_containerrrun.py
@@ -8,10 +8,8 @@ from .runstate import RunState, ACTIVE_STATES, FAIL_STATES
 
 
 def await_containerrun(containerrun: KiveRun) -> KiveRun:
-    """
-    Given a `KiveAPI instance and a container run, monitor the run
-    for completion and return the completed run.
-    """
+    """Given a `KiveAPI` instance and a container run, monitor the run for
+    completion and return the completed run."""
 
     INTERVAL = 1.0
     MAX_WAIT = float("inf")


### PR DESCRIPTION
## Summary
- update await_containerrun docstring for clarity and grammar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f3ea7aae0832e8e754c7d83505d74