### PR TITLE
Improve README usage info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,25 @@
 
 Collection of scripts to interact with the [Kive platform](https://github.com/cfe-lab/Kive) from the comfort of your terminal.
 
+## Environment variables
+
+`kivecli` relies on a few variables for authentication.
+
+```bash
+export MICALL_KIVE_SERVER=https://kive.example.com
+export MICALL_KIVE_USER=myuser
+export MICALL_KIVE_PASSWORD=secret
+```
+
+## Example usage
+
+Run a simple pipeline:
+
+```bash
+kivecli run my_app input_dataset
+```
+
 # License
 
 This program is licensed under GNU GENERAL PUBLIC LICENSE version 3.
-More defails in the [COPYING](./COPYING) file.
+More details in the [COPYING](./COPYING) file.


### PR DESCRIPTION
## Summary
- clarify README wording
- document environment variables for authenticating to Kive
- add a basic subcommand example

## Testing
- `pytest -v`
- `mypy`

------
https://chatgpt.com/codex/tasks/task_e_683f548b4704832ea743d1007bdcd33c