### PR TITLE
Fix Python shebangs

### DIFF
--- a/src/kivecli/createpipelinejson.py
+++ b/src/kivecli/createpipelinejson.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import argparse
 import json

--- a/src/kivecli/download.py
+++ b/src/kivecli/download.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import argparse
 import os

--- a/src/kivecli/watch.py
+++ b/src/kivecli/watch.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import argparse
 from typing import Sequence


### PR DESCRIPTION
## Summary
- standardize python shebangs in scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kiveapi')*

------
https://chatgpt.com/codex/tasks/task_e_683f549cb198832e860b99bf7ea60f3b