### PR TITLE
Fix name typos for await_containerrun

### DIFF
--- a/src/kivecli/await_containerrun.py
+++ b/src/kivecli/await_containerrun.py
@@ -1,4 +1,3 @@
-
 import time
 from typing import Optional
 
@@ -8,10 +7,8 @@ from .runstate import RunState, ACTIVE_STATES, FAIL_STATES
 
 
 def await_containerrun(containerrun: KiveRun) -> KiveRun:
-    """
-    Given a `KiveAPI instance and a container run, monitor the run
-    for completion and return the completed run.
-    """
+    """Monitor a container run until it finishes and return the updated
+    ``KiveRun`` instance."""
 
     INTERVAL = 1.0
     MAX_WAIT = float("inf")

--- a/src/kivecli/download.py
+++ b/src/kivecli/download.py
@@ -14,7 +14,7 @@ from .collect_run_files import collect_run_files
 from .dataset import Dataset
 from .escape import escape
 from .usererror import UserError
-from .await_containerrrun import await_containerrun
+from .await_containerrun import await_containerrun
 from .runfilesfilter import RunFilesFilter
 from .kiverun import KiveRun
 

--- a/src/kivecli/runkive.py
+++ b/src/kivecli/runkive.py
@@ -19,7 +19,7 @@ from .parsecli import parse_cli
 from .login import login
 from .url import URL
 from .escape import escape
-from .await_containerrrun import await_containerrun
+from .await_containerrun import await_containerrun
 from .runfilesfilter import RunFilesFilter
 from .findbatches import findbatches
 from .kiverun import KiveRun

--- a/src/kivecli/watch.py
+++ b/src/kivecli/watch.py
@@ -8,7 +8,7 @@ from .mainwrap import mainwrap
 from .parsecli import parse_cli
 from .login import login
 from .findrun import find_run
-from .await_containerrrun import await_containerrun
+from .await_containerrun import await_containerrun
 
 
 def cli_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
## Summary
- rename `await_containerrrun.py` to `await_containerrun.py`
- update module imports
- clean up and format docstring in `await_containerrun`

## Testing
- `pip install -e .[test]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f54998930832eb3a8e7085929b22a